### PR TITLE
Cisco Catalyst Center - Stanadardization

### DIFF
--- a/DayN.md
+++ b/DayN.md
@@ -1,6 +1,6 @@
 ## DAY N Templates and Flows [![published](https://static.production.devnetcloud.com/codeexchange/assets/images/devnet-published.svg)](https://developer.cisco.com/codeexchange/github/repo/kebaldwi/DNAC-TEMPLATES)
 
-In this section we will go through the flow involved in creating a Template from an IOS configuration script for a Catalyst switch and various thoughts around how to link it to a Switch profile and deploy it through DNAC using Plug and Play workflows.
+In this section we will go through the flow involved in creating a Template from an IOS configuration script for a Catalyst switch and various thoughts around how to link it to a Switch profile and deploy it through Cisco Catalyst Center using Plug and Play workflows.
 
 Cisco Catalyst Center can be used for not only Plug and Play but also Day N or Ongoing Templates. Typically customers will start by building out an Onboarding Template which might deploy just enough information to bring the device up initially, or might include the entire configuration for a traditional network. Customers also need to be able to deploy ongoing changes to the network infrastructure.
 
@@ -94,7 +94,7 @@ If the Network Profile is already deployed it can be edited at a later date to a
 
 ## Provisioning
 
-At this point DNAC is set up and ready for DayN templates to be used on the first device. Provided the device has been onboarded or discovered by DNAC and is present in Cisco Catalyst Center Device Inventory. If not, please discover the device through the tools menu or see the onboarding section [Onboarding Templates](./Onboarding.md)
+At this point Cisco Catalyst Center is set up and ready for DayN templates to be used on the first device. Provided the device has been onboarded or discovered by Cisco Catalyst Center and is present in Cisco Catalyst Center Device Inventory. If not, please discover the device through the tools menu or see the onboarding section [Onboarding Templates](./Onboarding.md)
 
 At this point you can select the device putting on the Device Inventory and provision it by do the following:
 

--- a/ExamplesAndConcepts.md
+++ b/ExamplesAndConcepts.md
@@ -30,7 +30,7 @@ To help get started with the PnP process and to better understand the process, p
 <summary> Click for Details and Sub Tasks</summary>
 
 1. [PnP Workflow](./PnP-Workflow.md) - This section explains the overall Plug and Play Methodology
-2. [Onboarding](./Onboarding.md) - This section will explain Onboarding Templates in DNAC and their use
+2. [Onboarding](./Onboarding.md) - This section will explain Onboarding Templates in Cisco Catalyst Center and their use
 3. [Building Templates](./Templates.md#building-templates) - This section will explain how to build a template on DNAC
 
 </details>

--- a/Jinja2.md
+++ b/Jinja2.md
@@ -2,7 +2,7 @@
 
 This section will describe the various tools and techniques used to make a powerful script out of normal CLI statement collections which are used by organizations on IOS devices around the world. This section is an attempt to demystify the hows and to bring clarity on what is truely possible. While it is possible to take a CLI script for one device and create a template for one device at a time, that would leave us with a lot of templates and make it harder to make changes on an ongoing basis. Using the techniques below will allow us to deploy equipment with scripts which can be reused, allowing us to keep configurations similar for conformity reasons but also to reduce the number of places where changes would have to be made. 
 
-To that end it is important to write modular scripts which make use of all the power of programming but allow us to do it within the DNAC platform as templates. 
+To that end it is important to write modular scripts which make use of all the power of programming but allow us to do it within the Cisco Catalyst Center platform as templates. 
 
 The Jinja2 language typically allows for logical constructs, macros and more. Its heredity is from the Python language and so a lot of its form, nomenclature and features will be very familiar to programmers familiar with Python.
 

--- a/Onboarding.md
+++ b/Onboarding.md
@@ -1,6 +1,6 @@
 # Onboarding Templates and Flows [![published](https://static.production.devnetcloud.com/codeexchange/assets/images/devnet-published.svg)](https://developer.cisco.com/codeexchange/github/repo/kebaldwi/DNAC-TEMPLATES)
 
-In this section will go through the flow involved in creating a Template from an IOS configuration script for a Catalyst switch and various thoughts around how to link it to a Switch profile and deploy it through DNAC using Plug and Play workflows.
+In this section will go through the flow involved in creating a Template from an IOS configuration script for a Catalyst switch and various thoughts around how to link it to a Switch profile and deploy it through Cisco Catalyst Center using Plug and Play workflows.
 
 Cisco Catalyst Center can be used for not only Plug and Play but also Day N or Ongoing Templates. Typically customers will start by building out an Onboarding Template which might deploy only enough information to bring the device up initially or it might include the entire configuration typical for a traditional networking device.
 
@@ -140,7 +140,7 @@ If the Network Profile is already deployed it can be edited at a later date to a
 
 ## Claiming and Provisioning
 
-At this point DNAC is set up and ready for Plug and Play to onboard the first device. Provided Cisco Catalyst Center discovery methods are properly configured (ie DHCP-based, or DNS record-based), the out-of-box device during boot up process discover Cisco Catalyst Center, and register itself in the plug n play section of the provisioning page.
+At this point Cisco Catalyst Center is set up and ready for Plug and Play to onboard the first device. Provided Cisco Catalyst Center discovery methods are properly configured (ie DHCP-based, or DNS record-based), the out-of-box device during boot up process discover Cisco Catalyst Center, and register itself in the plug n play section of the provisioning page.
 
 At this point you can claim the device putting it in a planned state for onboarding onto the system. To do this do the following:
 

--- a/PnP-Workflow.md
+++ b/PnP-Workflow.md
@@ -82,7 +82,7 @@ If DHCP Option 43 is not configured, the device cannot contact the DHCP server, 
 
 **Option 2:** requires that along with the IP address and gateway the DHCP server offer the domain suffix that the **pnpserver** record will reside in and a name server to resolve the address. Caveats here would be that if not all devices were to be landing on Cisco Catalyst Center then you may need sub domains.
 
-**Option 3:** requires that along with the address and the gateway the DHCP server offer a name server to resolve the address of **device-helper.cisco.com**. Additionally it requires the that Cisco Catalyst Center registers a file with the PnP Connect portal which it will offer via SSL to a device which reaches out. In order to whitelist those devices, the serial number would have to be associated to the DNAC profile within "Software Central" > [Plug and Play Connect](https://software.cisco.com/software/csws/ws/platform/home?locale=en_US#pnp-devices) portal.
+**Option 3:** requires that along with the address and the gateway the DHCP server offer a name server to resolve the address of **device-helper.cisco.com**. Additionally it requires the that Cisco Catalyst Center registers a file with the PnP Connect portal which it will offer via SSL to a device which reaches out. In order to whitelist those devices, the serial number would have to be associated to the Cisco Catalyst Center profile within "Software Central" > [Plug and Play Connect](https://software.cisco.com/software/csws/ws/platform/home?locale=en_US#pnp-devices) portal.
 
 ![json](images/pnp-connect.png?raw=true "Import JSON")
 

--- a/Python.md
+++ b/Python.md
@@ -161,7 +161,7 @@ pip install requests
 
 > **Note:** It is considered to be a best practice to not store credentials in plain text, and instead leveraging environment variables. This example is for simplicity and demonstration purposes only.
 
-> **Note:** Please ensure to update DNAC URL, and credentials to match Cisco Catalyst Center environment you are working with (in this case, parameters are for devnet sandbox).
+> **Note:** Please ensure to update Cisco Catalyst Center URL, and credentials to match Cisco Catalyst Center environment you are working with (in this case, parameters are for devnet sandbox).
 
 ```python
 import os
@@ -297,7 +297,7 @@ from dnac_config import DNAC, DNAC_USER, DNAC_PASSWORD
 
 def get_auth_dnac():
     """
-    Leverage SDK to return a DNAC object
+    Leverage SDK to return a Cisco Catalyst Center object
     """
     dnac = api.DNACenterAPI(base_url="https://{DNAC}".format(DNAC=DNAC),
                             username=DNAC_USER,password=DNAC_PASSWORD,verify=False)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The repository will include scripts and examples with the following:
 5. Regular Templates
 6. Composite Templates
 
-The goal of this repository is a practical guide to allow engineers to rapidly begin using DNAC automation and begin conversion of IOS CLI Templates. The Templates have been developed over the years and with various use cases in mind, and so the intent of sharing this collection is to reduce the lift to begin automating.
+The goal of this repository is a practical guide to allow engineers to rapidly begin using Cisco Catalyst Center automation and begin conversion of IOS CLI Templates. The Templates have been developed over the years and with various use cases in mind, and so the intent of sharing this collection is to reduce the lift to begin automating.
 
 ## Intent Based Networking
 
@@ -40,12 +40,12 @@ You will find various examples within the various folders of this repository, wi
 ### Workflows
 
 * [PnP Workflow](https://github.com/kebaldwi/DNAC-TEMPLATES/tree/master/PnP-Workflow.md#pnp-workflow) - This section explains the overall Plug and Play Methodology
-* [Onboarding Templates](https://github.com/kebaldwi/DNAC-TEMPLATES/tree/master/Onboarding.md#onboarding-templates-and-flows) - This section will explain Onboarding Templates in DNAC and their use in bringing various devices under Cisco Catalyst Center management
+* [Onboarding Templates](https://github.com/kebaldwi/DNAC-TEMPLATES/tree/master/Onboarding.md#onboarding-templates-and-flows) - This section will explain Onboarding Templates in Cisco Catalyst Center and their use in bringing various devices under Cisco Catalyst Center management
 * [DayN Templates](https://github.com/kebaldwi/DNAC-TEMPLATES/tree/master/DayN.md#day-n-templates-and-flows) - This section will explain how to use templates for ongoing (Day-N) changes to the network
 
 ### Templating
 
-* [Building Templates](https://github.com/kebaldwi/DNAC-TEMPLATES/tree/master/Templates.md#building-templates) - This section will explain how to build a template on DNAC from scratch
+* [Building Templates](https://github.com/kebaldwi/DNAC-TEMPLATES/tree/master/Templates.md#building-templates) - This section will explain how to build a template on Cisco Catalyst Center from scratch
 
 #### Velocity Language
 
@@ -89,7 +89,7 @@ This section built out in a lab format to guide you through the typical steps to
 * [Onboarding Templates](https://github.com/kebaldwi/DNAC-TEMPLATES/blob/master/LABS/LAB-B-Onboarding-Template/) - The lab covers in depth topics in deploying Day 0 templates **(allow 1.5 hrs)**
 * [Day N Templates](https://github.com/kebaldwi/DNAC-TEMPLATES/blob/master/LABS/LAB-C-DayN-Template/) - The lab covers Day N template constructs and use cases **(allow 0.5 hrs)**
 * [Composite Templates](https://github.com/kebaldwi/DNAC-TEMPLATES/blob/master/LABS/LAB-D-Composite-Template/) - This lab covers building a composite template on Cisco Catalyst Center **(allow 0.5 hrs)**
-* [Application Policys](https://github.com/kebaldwi/DNAC-TEMPLATES/tree/master/LABS/LAB-E-Application-Policy/) - This lab covers Application Policy & SDAVC in DNAC **(allow 1.0 hrs)**
+* [Application Policys](https://github.com/kebaldwi/DNAC-TEMPLATES/tree/master/LABS/LAB-E-Application-Policy/) - This lab covers Application Policy & SDAVC in Cisco Catalyst Center **(allow 1.0 hrs)**
 * [Telemetry](https://github.com/kebaldwi/DNAC-TEMPLATES/tree/master/LABS/LAB-F-Telemetry-Enablement/) - This lab explains how to deploy Streaming Telemetry for Cisco Catalyst Center Assurance **(allow 0.5 hrs)**
 * [Advanced Automation](https://github.com/kebaldwi/DNAC-TEMPLATES/tree/master/LABS/LAB-G-Advanced-Automation/) - This lab will explore Advanced Automation examples **(allow 1.5 hrs)**
 * [Dynamic Automation](https://github.com/kebaldwi/DNAC-TEMPLATES/tree/master/LABS/LAB-H-Dynamic-Automation/) - This lab will explore additional Advanced Automation examples **(allow 2.0 hrs)**


### PR DESCRIPTION
Removing / Modifying 'DNAC' nomenclature and standardizing to 'Cisco Catalyst Center on all tutorials.